### PR TITLE
Make otlp exporter headers conditional on auth headers being used

### DIFF
--- a/src/main/java/io/jenkins/plugins/onmonit/ONMonitoringStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONMonitoringStepExecution.java
@@ -235,6 +235,9 @@ public class ONMonitoringStepExecution extends StepExecution implements Launcher
 			throw new NullPointerException("build is null");
 		}
 		String config = templating.renderTemplate(templating.getJobContext(build, build.getEnvironment(listener), usedPort.getPort()));
+		if (debug) {
+			listener.getLogger().println("[on-monit] otel-collector config:\n" + config);
+		}
 		otelContrib.start(listener, config);
 		listener.getLogger().println(Messages.ONMonitoringStep_Started());
 	}

--- a/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
@@ -100,11 +100,15 @@ public class ONTemplating {
         context.setVariable("jobGroupName", trimWithDefault(jobName, jobBaseName, "-"));
         context.setVariable("otlpEndpoint", toOtelCompatibleUrl(otlpEndpoint));
         if (otlpHeader == null || otlpHeader.isEmpty()) {
-            context.setVariable("otlpAuthHeaders", "");
+            context.setVariable("otlpAuthHeaderBefore", "");
+            context.setVariable("otlpAuthHeader", "");
+            context.setVariable("otlpAuthHeaderAfter", "");
         } else {
             var otlpAuthHeader = otlpHeader.substring(otlpHeader.indexOf("=") + 1);
-            context.setVariable("otlpAuthHeaders", "headers:\n" +
-                    "      Authorization: '" + otlpAuthHeader + "'" );
+            context.setVariable("otlpAuthHeaderBefore", "headers:\n" +
+                    "      Authorization: '");
+            context.setVariable("otlpAuthHeader", otlpAuthHeader);
+            context.setVariable("otlpAuthHeaderAfter", "'" );
         }
         return context;
     }

--- a/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
@@ -97,7 +97,13 @@ public class ONTemplating {
         context.setVariable("jobName", jobName);
         context.setVariable("jobGroupName", trimWithDefault(jobName, jobBaseName, "-"));
         context.setVariable("otlpEndpoint", toOtelCompatibleUrl(otlpEndpoint));
-        context.setVariable("otlpAuthHeader", otlpHeader.substring(otlpHeader.indexOf("=") + 1));
+        if (otlpHeader == null || otlpHeader.isEmpty()) {
+            context.setVariable("otlpAuthHeaders", "");
+        } else {
+            var otlpAuthHeader = otlpHeader.substring(otlpHeader.indexOf("=") + 1);
+            context.setVariable("otlpAuthHeaders", "headers:\n" +
+                    "      Authorization: \"" + otlpAuthHeader + "\"" );
+        }
         return context;
     }
 

--- a/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
@@ -40,8 +40,10 @@ public class ONTemplating {
         if (configTemplateEngine != null) {
             return configTemplateEngine;
         }
+        final StringTemplateResolver templateResolver = new StringTemplateResolver();
+        templateResolver.setTemplateMode(TemplateMode.TEXT);
         final TemplateEngine tEngine = new TemplateEngine();
-        tEngine.setTemplateResolver(new StringTemplateResolver());
+        tEngine.setTemplateResolver(templateResolver);
         configTemplateEngine = tEngine;
         return configTemplateEngine;
     }

--- a/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
@@ -102,7 +102,7 @@ public class ONTemplating {
         } else {
             var otlpAuthHeader = otlpHeader.substring(otlpHeader.indexOf("=") + 1);
             context.setVariable("otlpAuthHeaders", "headers:\n" +
-                    "      Authorization: \"" + otlpAuthHeader + "\"" );
+                    "      Authorization: '" + otlpAuthHeader + "'" );
         }
         return context;
     }

--- a/src/main/resources/io/jenkins/plugins/onmonit/otel.yaml.tmpl
+++ b/src/main/resources/io/jenkins/plugins/onmonit/otel.yaml.tmpl
@@ -11,7 +11,7 @@ exporters:
     loglevel: debug
   otlp:
     endpoint: "[[${otlpEndpoint}]]"
-    [[${otlpAuthHeaders}]]
+    [(${otlpAuthHeaderBefore})][[${otlpAuthHeader}]][(${otlpAuthHeaderAfter})]
 
 processors:
   resourcedetection:

--- a/src/main/resources/io/jenkins/plugins/onmonit/otel.yaml.tmpl
+++ b/src/main/resources/io/jenkins/plugins/onmonit/otel.yaml.tmpl
@@ -11,8 +11,7 @@ exporters:
     loglevel: debug
   otlp:
     endpoint: "[[${otlpEndpoint}]]"
-    headers:
-      Authorization: "[[${otlpAuthHeader}]]"
+    [[${otlpAuthHeaders}]]
 
 processors:
   resourcedetection:


### PR DESCRIPTION
Fixes #43

We make the auth headers in the otlp exporter  config section conditional on the `OTEL_EXPORTER_OTLP_HEADERS` environment variable being set (eg. as configured by the opentelemetry-plugin).

### Testing done

Manual testing was done with and without `OTEL_EXPORTER_OTLP_HEADERS` env var defined.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- Link to relevant pull requests, esp. upstream and downstream changes → NA
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
