### PR TITLE
Remove hard-coded service name

### DIFF
--- a/ci-pod-metrics-dashboard.json
+++ b/ci-pod-metrics-dashboard.json
@@ -2541,8 +2541,8 @@
         {
           "current": {
             "selected": false,
-            "text": "secuchat--test-k8s-20-k3019-j0kpp-rxl7l",
-            "value": "secuchat--test-k8s-20-k3019-j0kpp-rxl7l"
+            "text": "-",
+            "value": "-"
           },
           "datasource": {
             "type": "prometheus",
@@ -2596,9 +2596,9 @@
         },
         {
           "current": {
-            "selected": true,
-            "text": "SecuChat__Test-K8s",
-            "value": "SecuChat__Test-K8s"
+            "selected": false,
+            "text": "-",
+            "value": "-"
           },
           "datasource": {
             "type": "prometheus",

--- a/src/main/java/io/jenkins/plugins/onmonit/ONMonitConfig.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONMonitConfig.java
@@ -273,7 +273,7 @@ public final class ONMonitConfig extends GlobalConfiguration {
 	/**
 	 * Set the OpenTelemetry service name.
 	 *
-	 * @param otelServiceName the OTEL configuration template
+	 * @param otelServiceName the otel service name
 	 */
 	public void setOtelServiceName(@CheckForNull String otelServiceName) {
 		this.otelServiceName = otelServiceName != null ? otelServiceName.trim() : null;

--- a/src/main/java/io/jenkins/plugins/onmonit/ONMonitConfig.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONMonitConfig.java
@@ -120,6 +120,12 @@ public final class ONMonitConfig extends GlobalConfiguration {
 	@CheckForNull
 	private String otelConfigTemplate;
 
+	/**
+	 * Use a custom OpenTelemetry service name.
+	 */
+	@CheckForNull
+	private String otelServiceName;
+
 	/** Constructor. */
 	public ONMonitConfig() {
 		load();
@@ -252,6 +258,25 @@ public final class ONMonitConfig extends GlobalConfiguration {
 	 */
 	public void setOtelConfigTemplate(@CheckForNull String otelConfigTemplate) {
 		this.otelConfigTemplate = otelConfigTemplate != null ? otelConfigTemplate.trim() : null;
+		save();
+	}
+
+	/**
+	 * Get the OpenTelemetry service name.
+	 *
+	 * @return the otel service name
+	 */
+	public String getOtelServiceName() {
+		return otelServiceName == null ? "" : otelServiceName;
+	}
+
+	/**
+	 * Set the OpenTelemetry service name.
+	 *
+	 * @param otelServiceName the OTEL configuration template
+	 */
+	public void setOtelServiceName(@CheckForNull String otelServiceName) {
+		this.otelServiceName = otelServiceName != null ? otelServiceName.trim() : null;
 		save();
 	}
 

--- a/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONTemplating.java
@@ -89,13 +89,17 @@ public class ONTemplating {
         String pageUrl = Jenkins.get().getRootUrl() + run.getUrl();
         String otlpEndpoint = environment.get("OTEL_EXPORTER_OTLP_ENDPOINT");
         String otlpHeader = environment.get("OTEL_EXPORTER_OTLP_HEADERS");
+        String serviceName = environment.get("OTEL_SERVICE_NAME");
+        if (serviceName == null) {
+            serviceName = ONMonitConfig.get().getOtelServiceName();
+        }
         String jobName = environment.get("JOB_NAME");
         String jobBaseName = environment.get("JOB_BASE_NAME");
         context.setVariable("JENKINS_URL", Jenkins.get().getRootUrl());
         context.setVariable("pageUrl", pageUrl);
         context.setVariable("env", environment);
         context.setVariable("nePort", port);
-        context.setVariable("serviceName", "ci_jemmic_com");
+        context.setVariable("serviceName", serviceName);
         context.setVariable("jobName", jobName);
         context.setVariable("jobGroupName", trimWithDefault(jobName, jobBaseName, "-"));
         context.setVariable("otlpEndpoint", toOtelCompatibleUrl(otlpEndpoint));

--- a/src/main/resources/io/jenkins/plugins/onmonit/ONMonitConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/onmonit/ONMonitConfig/config.jelly
@@ -13,6 +13,9 @@
     <f:entry field="ocDefaultAdditionalOptions" title="${%Otel-contrib default additional options}">
       <f:textbox />
     </f:entry>
+    <f:entry field="otelServiceName" title="${%OpenTelemetry service name}">
+      <f:textbox />
+    </f:entry>
     <f:entry field="otelConfigTemplate" title="${%OTEL configuration template}">
       <f:textarea />
     </f:entry>

--- a/src/main/resources/io/jenkins/plugins/onmonit/ONMonitConfig/help-otelServiceName.html
+++ b/src/main/resources/io/jenkins/plugins/onmonit/ONMonitConfig/help-otelServiceName.html
@@ -1,0 +1,3 @@
+<div>
+    This allows specifying the <a href="https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_service_name">OpenTelemetry service name</a> used for the node agent metrics.
+</div>


### PR DESCRIPTION
Fixes #87 

This PR removes hard-coded company and application names.

To remain backwards-compatible a global configuration option "OpenTelemetry service name" has been added to configure the service name.

### Testing done

Manual testing was done to verify:
* no env var or value of the global option does not cause a NullPointerException (empty service name)
* setting the global option correctly sets the otel-collector config

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- Link to relevant pull requests, esp. upstream and downstream changes → NA
- Ensure you have provided tests that demonstrate the feature works or the issue is fixed → NA

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
