### PR TITLE
Convert cicd.pipeline.run.info metric type from counter to gauge, removes _total suffix from metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Launching `node_exporter` and `otelcol-contrib` processes must be disabled in th
 `launchCollector: false`.
 
 The [ci-pod-metrics-dashboard.json](ci-pod-metrics-dashboard.json) dashboard allows filtering for the pods used as agents
-by filtering on a `cicd_pipeline_run_info_total` metric produced on the basis of the spans emitted by the [opentelemetry-plugin](https://github.com/jenkinsci/opentelemetry-plugin/)
+by filtering on a `cicd_pipeline_run_info` metric produced on the basis of the spans emitted by the [opentelemetry-plugin](https://github.com/jenkinsci/opentelemetry-plugin/)
 using an opentelemetry-collector pipeline (eg. using the [collector.yaml](collector.yaml) config).
 
 The dashboard json can be imported into Grafana and then the dashboard URL configured either in the global Jenkins onMonit config

--- a/ci-pod-metrics-dashboard.json
+++ b/ci-pod-metrics-dashboard.json
@@ -2519,14 +2519,14 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "definition": "label_values(cicd_pipeline_run_info_total{cicd_pipeline_name=\"$job\", cicd_pipeline_run_id=\"$jobid\",k8s_namespace_name!=\"-\"}, k8s_namespace_name)",
+          "definition": "label_values(cicd_pipeline_run_info{cicd_pipeline_name=\"$job\", cicd_pipeline_run_id=\"$jobid\",k8s_namespace_name!=\"-\"}, k8s_namespace_name)",
           "hide": 0,
           "includeAll": false,
           "multi": false,
           "name": "namespace",
           "options": [],
           "query": {
-            "query": "label_values(cicd_pipeline_run_info_total{cicd_pipeline_name=\"$job\", cicd_pipeline_run_id=\"$jobid\",k8s_namespace_name!=\"-\"}, k8s_namespace_name)",
+            "query": "label_values(cicd_pipeline_run_info{cicd_pipeline_name=\"$job\", cicd_pipeline_run_id=\"$jobid\",k8s_namespace_name!=\"-\"}, k8s_namespace_name)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 2,
@@ -2548,14 +2548,14 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "definition": "label_values(cicd_pipeline_run_info_total{cicd_pipeline_name=\"$job\", cicd_pipeline_run_id=\"$jobid\",k8s_pod_name!=\"-\"}, k8s_pod_name)",
+          "definition": "label_values(cicd_pipeline_run_info{cicd_pipeline_name=\"$job\", cicd_pipeline_run_id=\"$jobid\",k8s_pod_name!=\"-\"}, k8s_pod_name)",
           "hide": 0,
           "includeAll": false,
           "multi": false,
           "name": "pod",
           "options": [],
           "query": {
-            "query": "label_values(cicd_pipeline_run_info_total{cicd_pipeline_name=\"$job\", cicd_pipeline_run_id=\"$jobid\",k8s_pod_name!=\"-\"}, k8s_pod_name)",
+            "query": "label_values(cicd_pipeline_run_info{cicd_pipeline_name=\"$job\", cicd_pipeline_run_id=\"$jobid\",k8s_pod_name!=\"-\"}, k8s_pod_name)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 2,
@@ -2577,7 +2577,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "definition": "label_values(cicd_pipeline_run_info_total, cicd_pipeline_group)",
+          "definition": "label_values(cicd_pipeline_run_info, cicd_pipeline_group)",
           "hide": 0,
           "includeAll": false,
           "label": "Job group",
@@ -2585,7 +2585,7 @@
           "name": "jobgroup",
           "options": [],
           "query": {
-            "query": "label_values(cicd_pipeline_run_info_total, cicd_pipeline_group)",
+            "query": "label_values(cicd_pipeline_run_info, cicd_pipeline_group)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -2604,7 +2604,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "definition": "label_values(cicd_pipeline_run_info_total{cicd_pipeline_group=\"$jobgroup\"}, cicd_pipeline_name)",
+          "definition": "label_values(cicd_pipeline_run_info{cicd_pipeline_group=\"$jobgroup\"}, cicd_pipeline_name)",
           "hide": 0,
           "includeAll": false,
           "label": "Job",
@@ -2612,7 +2612,7 @@
           "name": "job",
           "options": [],
           "query": {
-            "query": "label_values(cicd_pipeline_run_info_total{cicd_pipeline_group=\"$jobgroup\"}, cicd_pipeline_name)",
+            "query": "label_values(cicd_pipeline_run_info{cicd_pipeline_group=\"$jobgroup\"}, cicd_pipeline_name)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -2631,7 +2631,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "definition": "label_values(cicd_pipeline_run_info_total{cicd_pipeline_name=\"$job\"}, cicd_pipeline_run_id)",
+          "definition": "label_values(cicd_pipeline_run_info{cicd_pipeline_name=\"$job\"}, cicd_pipeline_run_id)",
           "hide": 0,
           "includeAll": true,
           "label": "Job ID",
@@ -2639,7 +2639,7 @@
           "name": "jobid",
           "options": [],
           "query": {
-            "query": "label_values(cicd_pipeline_run_info_total{cicd_pipeline_name=\"$job\"}, cicd_pipeline_run_id)",
+            "query": "label_values(cicd_pipeline_run_info{cicd_pipeline_name=\"$job\"}, cicd_pipeline_run_id)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 2,

--- a/collector.yaml
+++ b/collector.yaml
@@ -77,12 +77,15 @@ spec:
         #- sources:
         #    # This rule will use the IP from the incoming connection from which the resource is received, and find the matching pod, based on the 'pod.status.podIP' of the observed pods
         #    - from: connection
-      transform:
+      transform/span:
         # Convert all resource attributes (including any newly detected k8s attributes) to span attributes because the count connector only works on span attributes.
         trace_statements:
         - context: span
           statements:
           - 'merge_maps(attributes, resource.attributes, "insert")'
+      transform/metric:
+        metric_statements:
+          - 'convert_sum_to_gauge() where metric.name == "cicd.pipeline.run.info"'
 
     exporters:
       debug: {}
@@ -103,12 +106,14 @@ spec:
           - attributes/k8sIP
           - groupbyattrs
           - k8sattributes
-          - transform
+          - transform/span
           exporters:
           - count
         metrics: # expose the CI info metric
           receivers:
           - count
+          processors:
+          - transform/metric
           exporters:
           - debug
           - prometheus


### PR DESCRIPTION
Fixes #80

Improve the otel-collector config for ci-pod-metrics to convert the info metric type from counter to gauge.
This ensures that when exported to prometheus the only change to the metric name will be to change `.` to `_` and no `_total` suffix is added.

Additionally the dashboard and README are adapted accordingly.

### Testing done

Manual testing was done.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- Link to relevant pull requests, esp. upstream and downstream changes → NA
- Ensure you have provided tests that demonstrate the feature works or the issue is fixed → NA

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
