### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <error-prone.version>2.50.0</error-prone.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     </properties>
     <name>Otel agent host metrics monitoring</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -41,6 +42,10 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>

--- a/src/main/java/io/jenkins/plugins/onmonit/ONMonitoringStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/ONMonitoringStepExecution.java
@@ -9,7 +9,7 @@ import io.jenkins.plugins.onmonit.util.AvailablePortRetriever;
 import io.jenkins.plugins.onmonit.util.ComputerInfo;
 import io.jenkins.plugins.onmonit.util.RemoteComputerInfoRetriever;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;

--- a/src/main/java/io/jenkins/plugins/onmonit/exec/DelegatedNodeExporterProcessFactory.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/exec/DelegatedNodeExporterProcessFactory.java
@@ -8,7 +8,7 @@ import io.jenkins.plugins.onmonit.LauncherProvider;
 import io.jenkins.plugins.onmonit.RemoteNodeExporterProcess;
 import io.jenkins.plugins.onmonit.RemoteNodeExporterProcessFactory;
 import io.jenkins.plugins.onmonit.util.ComputerInfo;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/src/main/java/io/jenkins/plugins/onmonit/exec/DelegatedOtelContribProcessFactory.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/exec/DelegatedOtelContribProcessFactory.java
@@ -8,7 +8,7 @@ import io.jenkins.plugins.onmonit.LauncherProvider;
 import io.jenkins.plugins.onmonit.RemoteOtelContribProcess;
 import io.jenkins.plugins.onmonit.RemoteOtelContribProcessFactory;
 import io.jenkins.plugins.onmonit.util.ComputerInfo;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/src/main/java/io/jenkins/plugins/onmonit/exec/ExecRemoteNodeExporterProcess.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/exec/ExecRemoteNodeExporterProcess.java
@@ -9,7 +9,7 @@ import io.jenkins.plugins.onmonit.util.ComputerInfo;
 import org.apache.commons.io.output.TeeOutputStream;
 import io.jenkins.plugins.onmonit.LauncherProvider;
 import hudson.FilePath;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/main/java/io/jenkins/plugins/onmonit/exec/ExecRemoteOtelContribProcess.java
+++ b/src/main/java/io/jenkins/plugins/onmonit/exec/ExecRemoteOtelContribProcess.java
@@ -9,7 +9,7 @@ import io.jenkins.plugins.onmonit.LauncherProvider;
 import io.jenkins.plugins.onmonit.RemoteOtelContribProcess;
 import io.jenkins.plugins.onmonit.util.ComputerInfo;
 import org.apache.commons.io.output.TeeOutputStream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed
- `StringUtils` moves to `org.apache.commons.lang3` via the `commons-lang3-api` library plugin
  (versionless — the version comes from the Jenkins plugin BOM).
- Enabled the `ban-commons-lang-2` enforcer rule to prevent regressions.

I kept `StringUtils.split` rather than rewriting it natively on purpose: `StringUtils.split(s, "\n")`
discards empty tokens, whereas `String.split("\n")` keeps them. Staying on the library keeps that
behaviour identical.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
